### PR TITLE
Update file name on Twine upload

### DIFF
--- a/.github/workflows/package_release.yml
+++ b/.github/workflows/package_release.yml
@@ -1,5 +1,6 @@
 #
-# Under Construction
+# Upload Release with Twine for tags starting with "v".
+#
 # References:
 #
 # https://futurestud.io/tutorials/github-actions-run-a-workflow-when-creating-a-tag
@@ -35,4 +36,4 @@ jobs:
       - run: python setup.py sdist
       # Note: if version from tag and one from within setup.py do not match,
       #       next step will fail. Let it as is for an additional check.
-      - run: twine upload "dist/alt-profanity-check-${{ steps.get_version.outputs.VERSION }}.tar.gz"
+      - run: twine upload "dist/alt_profanity_check-${{ steps.get_version.outputs.VERSION }}.tar.gz"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * scikit-learn to 1.5.0
 * Drop of Python 3.8 and updated README
+* Updates on Github Actions
 
 ## Version 1.4.2
 


### PR DESCRIPTION
Most probably a version update changed it, from running locally file generated is the following:

dist/alt_profanity_check-1.5.0.tar.gz